### PR TITLE
トーク画面TOP全体を作成

### DIFF
--- a/lib/app/modules/chat/controllers/chat_controller.dart
+++ b/lib/app/modules/chat/controllers/chat_controller.dart
@@ -1,10 +1,9 @@
 import 'package:get/get.dart';
 
 class ChatController extends GetxController {
-  final isGroupTalk = false.obs;
+  final RxBool isGroupTalk = false.obs;
 
-  RxBool? flagInversion(flag) {
-    flag.value = !flag.value;
-    return flag;
+  void switchTalkPartner() {
+    isGroupTalk.value = !isGroupTalk.value;
   }
 }

--- a/lib/app/modules/chat/views/chat_view.dart
+++ b/lib/app/modules/chat/views/chat_view.dart
@@ -6,91 +6,89 @@ import 'package:get/get.dart';
 
 import '../controllers/chat_controller.dart';
 
+//FIXME: チャット画面実装時にグループトークリストとの繋ぎこみを作成
+//       動作確認のためテスト値を入れている。本来は[]で初期化。
+List<TalkMemberCard> _individualTalkMemberCardList = [
+  const TalkMemberCard(
+    roomName: '文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認',
+    mostRecentMessage:
+        '文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'Aさん',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'Aさん',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'Aさん',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'Aさん',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'Aさん',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'Aさん',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'Aさん',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'Aさん',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+];
+
+//FIXME: チャット画面実装時にグループトークリストとの繋ぎこみを作成
+//       動作確認のためテスト値を入れている。本来は[]で初期化。
+List<TalkMemberCard> _groupTalkMemberCardList = [
+  const TalkMemberCard(
+    roomName: 'グループA',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'グループB',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'グループC',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'グループD',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+  const TalkMemberCard(
+    roomName: 'グループE',
+    mostRecentMessage: '私も〇〇好きです',
+    profileImageURL: null,
+  ),
+];
+
 class ChatView extends GetView<ChatController> {
-  ChatView({Key? key}) : super(key: key);
-
-  final chatController = Get.put(ChatController());
-
-  //FIXME: チャット画面実装時にグループトークリストとの繋ぎこみを作成
-  //       動作確認のためテスト値を入れている。本来は[]で初期化。
-  final List<TalkMemberCard> individualTalkMemberCardList = [
-    const TalkMemberCard(
-      roomName: '文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認',
-      mostRecentMessage:
-          '文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'Aさん',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'Aさん',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'Aさん',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'Aさん',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'Aさん',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'Aさん',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'Aさん',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'Aさん',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-  ];
-
-  //FIXME: チャット画面実装時にグループトークリストとの繋ぎこみを作成
-  //       動作確認のためテスト値を入れている。本来は[]で初期化。
-  final List<TalkMemberCard> groupTalkMemberCardList = [
-    const TalkMemberCard(
-      roomName: 'グループA',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'グループB',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'グループC',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'グループD',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-    const TalkMemberCard(
-      roomName: 'グループE',
-      mostRecentMessage: '私も〇〇好きです',
-      profileImageURL: null,
-    ),
-  ];
+  const ChatView({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -103,10 +101,10 @@ class ChatView extends GetView<ChatController> {
           IconButton(
             //TODO: トーク画面実装時にonpressedの画面切替処理を実装
             onPressed: () {
-              chatController.flagInversion(chatController.isGroupTalk);
+              controller.switchTalkPartner();
             },
             icon: Obx(
-              () => chatController.isGroupTalk.value
+              () => controller.isGroupTalk.value
                   ? const Icon(
                       Icons.groups,
                       size: 32,
@@ -122,10 +120,10 @@ class ChatView extends GetView<ChatController> {
           IconButton(
             //TODO: トーク画面実装時にonpressedの画面切替処理を実装
             onPressed: () {
-              chatController.flagInversion(chatController.isGroupTalk);
+              controller.switchTalkPartner();
             },
             icon: Obx(
-              () => chatController.isGroupTalk.value
+              () => controller.isGroupTalk.value
                   ? Icon(
                       Icons.person,
                       color: Colors.grey.shade300,
@@ -140,9 +138,9 @@ class ChatView extends GetView<ChatController> {
       ),
       body: Obx(
         () => ListView(
-          children: chatController.isGroupTalk.value
-              ? groupTalkMemberCardList
-              : individualTalkMemberCardList,
+          children: controller.isGroupTalk.value
+              ? _groupTalkMemberCardList
+              : _individualTalkMemberCardList,
         ),
       ),
       floatingActionButton: Container(

--- a/lib/app/modules/chat/views/talk_member_card.dart
+++ b/lib/app/modules/chat/views/talk_member_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class TalkMemberCard extends Card {
+class TalkMemberCard extends StatelessWidget {
   const TalkMemberCard({
     Key? key,
     required this.roomName,

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -29,7 +29,7 @@ class AppPages {
     ),
     GetPage(
       name: _Paths.chat,
-      page: () => ChatView(),
+      page: () => const ChatView(),
       binding: ChatBinding(),
     ),
     GetPage(


### PR DESCRIPTION
# ✨ What's done

- [x] トーク画面TOPのヘッダを作成
- [x] トーク画面TOPのカードを作成
- [x] トーク画面TOPのボディー全体の構造を作成<br>
<img src="https://user-images.githubusercontent.com/49933865/198954138-14de262d-cd36-40e7-aa4e-bb5e21733e75.png" width=250><img src="https://user-images.githubusercontent.com/49933865/198954162-6d0984b7-ea9b-49f4-87c9-bf1102725523.png" width=250>

# 🚩 What's not done

- [x] floatingActionButtonを押下したときの動作は未実装。遷移先画面を作成するときに実装予定。
- [x] カードをタップしたときの画面遷移は未実装。遷移先画面を作成するときに実装予定。

# ✅ Test

- [x] エミュレータで動作確認

# 🔧 補足、備考

- その他特になし

# 🔀 マージ条件

- [x] レビューを通過する
- [ ] セルフマージする