### PR TITLE
トークTOP画面のカードからトークルーム画面への遷移処理を追加

### DIFF
--- a/lib/app/components/organisms/talk_member_card.dart
+++ b/lib/app/components/organisms/talk_member_card.dart
@@ -7,17 +7,20 @@ class TalkMemberCard extends StatelessWidget {
     Key? key,
     required this.roomName,
     required this.mostRecentMessage,
+    required this.onTap,
     this.profileImageURL,
   }) : super(key: key);
 
   final String roomName;
   final String mostRecentMessage;
   final String? profileImageURL;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => _moveToTalkRoom(roomName, profileImageURL),
+      onTap: () => onTap.call(),
+      // _moveToTalkRoom(roomName, profileImageURL),
       child: Card(
         elevation: 0,
         shape: RoundedRectangleBorder(

--- a/lib/app/components/organisms/talk_member_card.dart
+++ b/lib/app/components/organisms/talk_member_card.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'package:get/get.dart';
-
 class TalkMemberCard extends StatelessWidget {
   const TalkMemberCard({
     Key? key,
@@ -20,7 +18,6 @@ class TalkMemberCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () => onTap.call(),
-      // _moveToTalkRoom(roomName, profileImageURL),
       child: Card(
         elevation: 0,
         shape: RoundedRectangleBorder(
@@ -73,14 +70,6 @@ class TalkMemberCard extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-
-  //fixme: firebaseからプロフィールを受け取れるようになったら引数見直し
-  void _moveToTalkRoom(String roomName, String? profileImageURL) {
-    Get.toNamed(
-      '/talk-room',
-      arguments: [roomName, profileImageURL],
     );
   }
 }

--- a/lib/app/components/organisms/talk_member_card.dart
+++ b/lib/app/components/organisms/talk_member_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:get/get.dart';
+
 class TalkMemberCard extends StatelessWidget {
   const TalkMemberCard({
     Key? key,
@@ -14,57 +16,68 @@ class TalkMemberCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16.0),
-        side: BorderSide(
-          //FIXME: 各種項目の色はアプリ全体の色を管理するファイルから参照するように修正する
-          color: Colors.grey.shade300,
+    return GestureDetector(
+      onTap: () => _moveToTalkRoom(roomName, profileImageURL),
+      child: Card(
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16.0),
+          side: BorderSide(
+            //FIXME: 各種項目の色はアプリ全体の色を管理するファイルから参照するように修正する
+            color: Colors.grey.shade300,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(15),
+          child: Row(
+            children: [
+              CircleAvatar(
+                //TODO:firebase接続後に動作確認
+                //profileImageURLがあればその画像を表示、なければグレー背景でpersonアイコンを表示
+                foregroundImage: profileImageURL != null
+                    ? NetworkImage(profileImageURL!)
+                    : null,
+                backgroundColor: Colors.grey,
+                child: const Icon(
+                  Icons.person,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(
+                width: 20,
+              ),
+              Flexible(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      roomName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontSize: 20),
+                    ),
+                    Text(
+                      mostRecentMessage,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
-      child: Padding(
-        padding: const EdgeInsets.all(15),
-        child: Row(
-          children: [
-            CircleAvatar(
-              //TODO:firebase接続後に動作確認
-              //profileImageURLがあればその画像を表示、なければグレー背景でpersonアイコンを表示
-              foregroundImage: profileImageURL != null
-                  ? NetworkImage(profileImageURL!)
-                  : null,
-              backgroundColor: Colors.grey,
-              child: const Icon(
-                Icons.person,
-                color: Colors.white,
-              ),
-            ),
-            const SizedBox(
-              width: 20,
-            ),
-            Flexible(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    roomName,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(fontSize: 20),
-                  ),
-                  Text(
-                    mostRecentMessage,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
+    );
+  }
+
+  //fixme: firebaseからプロフィールを受け取れるようになったら引数見直し
+  void _moveToTalkRoom(String roomName, String? profileImageURL) {
+    Get.toNamed(
+      '/talk-room',
+      arguments: [roomName, profileImageURL],
     );
   }
 }

--- a/lib/app/components/pages/chat/bindings/chat_binding.dart
+++ b/lib/app/components/pages/chat/bindings/chat_binding.dart
@@ -1,3 +1,4 @@
+import 'package:favoritism_communication/app/components/pages/chat/providers/talk_member_card_model_provider.dart';
 import 'package:get/get.dart';
 
 import '../controllers/chat_controller.dart';
@@ -7,6 +8,9 @@ class ChatBinding extends Bindings {
   void dependencies() {
     Get.lazyPut<ChatController>(
       () => ChatController(),
+    );
+    Get.lazyPut(
+      () => TalkMemberCardModelProvider(),
     );
   }
 }

--- a/lib/app/components/pages/chat/controllers/chat_controller.dart
+++ b/lib/app/components/pages/chat/controllers/chat_controller.dart
@@ -1,7 +1,17 @@
+import 'package:favoritism_communication/app/components/pages/chat/providers/talk_member_card_model_provider.dart';
 import 'package:get/get.dart';
+import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 class ChatController extends GetxController {
   final RxBool isGroupTalk = false.obs;
+  final RefreshController refreshController = RefreshController();
+  final TalkMemberCardModelProvider provider = Get.find();
+
+  @override
+  void onInit() {
+    provider.fetchChatData();
+    super.onInit();
+  }
 
   void switchTalkPartner() {
     isGroupTalk.value = !isGroupTalk.value;

--- a/lib/app/components/pages/chat/providers/talk_member_card_model_provider.dart
+++ b/lib/app/components/pages/chat/providers/talk_member_card_model_provider.dart
@@ -1,0 +1,13 @@
+import 'package:favoritism_communication/app/components/pages/chat/talk_member_card_model_model.dart';
+import 'package:favoritism_communication/app/dummy_data/chat_dummy_data.dart';
+
+class TalkMemberCardModelProvider {
+  List<TalkMemberCardModel> individualTalks = [];
+  List<TalkMemberCardModel> groupTalks = [];
+
+  void fetchChatData() {
+    individualTalks =
+        privateChat.map((e) => TalkMemberCardModel.fromJson(e)).toList();
+    groupTalks = groupChat.map((e) => TalkMemberCardModel.fromJson(e)).toList();
+  }
+}

--- a/lib/app/components/pages/chat/talk_member_card_model_model.dart
+++ b/lib/app/components/pages/chat/talk_member_card_model_model.dart
@@ -1,0 +1,22 @@
+class TalkMemberCardModel {
+  String? roomName;
+  String? mostRecentMessage;
+  String? profileImageURL;
+
+  TalkMemberCardModel(
+      {this.roomName, this.mostRecentMessage, this.profileImageURL});
+
+  TalkMemberCardModel.fromJson(Map<String, dynamic> json) {
+    roomName = json['roomName'];
+    mostRecentMessage = json['mostRecentMessage'];
+    profileImageURL = json['profileImageURL'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+    data['roomName'] = roomName;
+    data['mostRecentMessage'] = mostRecentMessage;
+    data['profileImageURL'] = profileImageURL;
+    return data;
+  }
+}

--- a/lib/app/components/pages/chat/views/chat_view.dart
+++ b/lib/app/components/pages/chat/views/chat_view.dart
@@ -93,6 +93,12 @@ class ChatView extends GetView<ChatController> {
                       refreshController: controller.refreshController,
                       enablePullDown: false,
                       enablePullUp: false,
+                      onLoading: () {
+                        // fixme: スクロール処理を後で書く
+                      },
+                      onRefresh: () {
+                        // fixme: スクロール処理を後で書く
+                      },
                       child: ListView.builder(
                         itemCount: controller.provider.groupTalks.length,
                         itemBuilder: (context, index) {
@@ -119,6 +125,12 @@ class ChatView extends GetView<ChatController> {
                       refreshController: controller.refreshController,
                       enablePullDown: false,
                       enablePullUp: false,
+                      onLoading: () {
+                        // fixme: スクロール処理を後で書く
+                      },
+                      onRefresh: () {
+                        // fixme: スクロール処理を後で書く
+                      },
                       child: ListView.builder(
                         itemCount: controller.provider.individualTalks.length,
                         itemBuilder: (context, index) {

--- a/lib/app/components/pages/chat/views/chat_view.dart
+++ b/lib/app/components/pages/chat/views/chat_view.dart
@@ -1,93 +1,12 @@
 import 'package:favoritism_communication/app/components/organisms/nav_bar.dart';
 import 'package:favoritism_communication/app/components/organisms/talk_member_card.dart';
 import 'package:favoritism_communication/app/components/atoms/atoms.dart';
+import 'package:favoritism_communication/app/components/pages/chat/controllers/chat_controller.dart';
+import 'package:favoritism_communication/app/components/pages/chat/talk_member_card_model_model.dart';
+import 'package:favoritism_communication/app/components/templates/templates.dart';
 import 'package:favoritism_communication/app/routes/app_pages.dart';
 import 'package:flutter/material.dart';
-
 import 'package:get/get.dart';
-
-import '../controllers/chat_controller.dart';
-
-//FIXME: チャット画面実装時にグループトークリストとの繋ぎこみを作成
-//       動作確認のためテスト値を入れている。本来は[]で初期化。
-List<TalkMemberCard> _individualTalkMemberCardList = [
-  const TalkMemberCard(
-    roomName: '文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認',
-    mostRecentMessage:
-        '文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'Aさん',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'Aさん',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'Aさん',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'Aさん',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'Aさん',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'Aさん',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'Aさん',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'Aさん',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-];
-
-//FIXME: チャット画面実装時にグループトークリストとの繋ぎこみを作成
-//       動作確認のためテスト値を入れている。本来は[]で初期化。
-List<TalkMemberCard> _groupTalkMemberCardList = [
-  const TalkMemberCard(
-    roomName: 'グループA',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'グループB',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'グループC',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'グループD',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-  const TalkMemberCard(
-    roomName: 'グループE',
-    mostRecentMessage: '私も〇〇好きです',
-    profileImageURL: null,
-  ),
-];
 
 class ChatView extends GetView<ChatController> {
   const ChatView({Key? key}) : super(key: key);
@@ -169,11 +88,60 @@ class ChatView extends GetView<ChatController> {
           ),
           Expanded(
             child: Obx(
-              () => ListView(
-                children: controller.isGroupTalk.value
-                    ? _groupTalkMemberCardList
-                    : _individualTalkMemberCardList,
-              ),
+              () => controller.isGroupTalk.value
+                  ? CustomSmartRefresher(
+                      refreshController: controller.refreshController,
+                      enablePullDown: false,
+                      enablePullUp: false,
+                      child: ListView.builder(
+                        itemCount: controller.provider.groupTalks.length,
+                        itemBuilder: (context, index) {
+                          final TalkMemberCardModel group =
+                              controller.provider.groupTalks[index];
+                          return TalkMemberCard(
+                            onTap: () {
+                              Get.toNamed(
+                                Routes.talkRoom,
+                                arguments: [
+                                  group.roomName,
+                                  group.profileImageURL
+                                ],
+                              );
+                            },
+                            roomName: group.roomName ?? '',
+                            mostRecentMessage: group.mostRecentMessage ?? '',
+                            profileImageURL: group.profileImageURL,
+                          );
+                        },
+                      ),
+                    )
+                  : CustomSmartRefresher(
+                      refreshController: controller.refreshController,
+                      enablePullDown: false,
+                      enablePullUp: false,
+                      child: ListView.builder(
+                        itemCount: controller.provider.individualTalks.length,
+                        itemBuilder: (context, index) {
+                          final TalkMemberCardModel individual =
+                              controller.provider.individualTalks[index];
+                          return TalkMemberCard(
+                            onTap: () {
+                              Get.toNamed(
+                                Routes.talkRoom,
+                                arguments: [
+                                  individual.roomName ?? '',
+                                  individual.profileImageURL
+                                ],
+                              );
+                            },
+                            roomName: individual.roomName ?? '',
+                            mostRecentMessage:
+                                individual.mostRecentMessage ?? '',
+                            profileImageURL: individual.profileImageURL,
+                          );
+                        },
+                      ),
+                    ),
             ),
           ),
         ],

--- a/lib/app/components/pages/talk_room/bindings/talk_room_binding.dart
+++ b/lib/app/components/pages/talk_room/bindings/talk_room_binding.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../controllers/talk_room_controller.dart';
+
+class TalkRoomBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<TalkRoomController>(
+      () => TalkRoomController(),
+    );
+  }
+}

--- a/lib/app/components/pages/talk_room/controllers/talk_room_controller.dart
+++ b/lib/app/components/pages/talk_room/controllers/talk_room_controller.dart
@@ -1,0 +1,23 @@
+import 'package:get/get.dart';
+
+class TalkRoomController extends GetxController {
+  //TODO: Implement TalkRoomController
+
+  final count = 0.obs;
+  @override
+  void onInit() {
+    super.onInit();
+  }
+
+  @override
+  void onReady() {
+    super.onReady();
+  }
+
+  @override
+  void onClose() {
+    super.onClose();
+  }
+
+  void increment() => count.value++;
+}

--- a/lib/app/components/pages/talk_room/controllers/talk_room_controller.dart
+++ b/lib/app/components/pages/talk_room/controllers/talk_room_controller.dart
@@ -3,21 +3,4 @@ import 'package:get/get.dart';
 class TalkRoomController extends GetxController {
   //TODO: Implement TalkRoomController
 
-  final count = 0.obs;
-  @override
-  void onInit() {
-    super.onInit();
-  }
-
-  @override
-  void onReady() {
-    super.onReady();
-  }
-
-  @override
-  void onClose() {
-    super.onClose();
-  }
-
-  void increment() => count.value++;
 }

--- a/lib/app/components/pages/talk_room/views/talk_room_view.dart
+++ b/lib/app/components/pages/talk_room/views/talk_room_view.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:favoritism_communication/app/components/organisms/nav_bar.dart';
+import 'package:favoritism_communication/app/components/atoms/atoms.dart'
+    as atoms;
 
 import 'package:get/get.dart';
 
@@ -9,11 +12,12 @@ class TalkRoomView extends GetView<TalkRoomController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('TalkRoomView'),
-        centerTitle: true,
+      appBar: NavBar(
+        title: Get.arguments[0], //TalkMemberCard.roomName
+        leading: const atoms.BackButton(),
+        backgroundColor: Colors.pink,
       ),
-      body: Center(
+      body: const Center(
         child: Text(
           'TalkRoomView is working',
           style: TextStyle(fontSize: 20),

--- a/lib/app/components/pages/talk_room/views/talk_room_view.dart
+++ b/lib/app/components/pages/talk_room/views/talk_room_view.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import 'package:get/get.dart';
+
+import '../controllers/talk_room_controller.dart';
+
+class TalkRoomView extends GetView<TalkRoomController> {
+  const TalkRoomView({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('TalkRoomView'),
+        centerTitle: true,
+      ),
+      body: Center(
+        child: Text(
+          'TalkRoomView is working',
+          style: TextStyle(fontSize: 20),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/components/templates/custom_smartrefresher.dart
+++ b/lib/app/components/templates/custom_smartrefresher.dart
@@ -7,9 +7,9 @@ class CustomSmartRefresher extends StatelessWidget {
     required this.refreshController,
     required this.enablePullDown,
     required this.enablePullUp,
+    required this.child,
     this.onLoading,
     this.onRefresh,
-    this.child,
   });
 
   final RefreshController refreshController;
@@ -23,12 +23,13 @@ class CustomSmartRefresher extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scrollbar(
       child: SmartRefresher(
-          controller: refreshController,
-          enablePullDown: false,
-          enablePullUp: true,
-          onRefresh: () => onRefresh?.call(),
-          onLoading: () => onLoading?.call(),
-          child: child),
+        controller: refreshController,
+        enablePullDown: false,
+        enablePullUp: true,
+        onRefresh: () => onRefresh?.call(),
+        onLoading: () => onLoading?.call(),
+        child: child,
+      ),
     );
   }
 }

--- a/lib/app/dummy_data/chat_dummy_data.dart
+++ b/lib/app/dummy_data/chat_dummy_data.dart
@@ -1,0 +1,54 @@
+/// 後でJSONファイルから読み込む
+List<Map<String, dynamic>> privateChat = <Map<String, dynamic>>[
+  {
+    "roomName": "文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認",
+    "mostRecentMessage":
+        "文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認文字切れ確認",
+    "profileImageURL": "https://animeanime.jp/imgs/slider/526911.jpg"
+  },
+  {"roomName": "Aさん", "mostRecentMessage": "私も〇〇好きです", "profileImageURL": ""},
+  {"roomName": "Bさん", "mostRecentMessage": "私も〇〇好きです", "profileImageURL": ""},
+  {"roomName": "Cさん", "mostRecentMessage": "私も〇〇好きです", "profileImageURL": ""},
+  {"roomName": "Dさん", "mostRecentMessage": "私も〇〇好きです", "profileImageURL": ""},
+  {
+    "roomName": "Eさん",
+    "mostRecentMessage": "私も〇〇好きです",
+    "profileImageURL": "https://animeanime.jp/imgs/slider/526911.jpg"
+  }
+];
+
+List<Map<String, dynamic>> groupChat = [
+  {
+    "roomName": "グループA",
+    "mostRecentMessage": "私も〇〇好きです",
+    "profileImageURL":
+        "https://shikimori-anime.com/core_sys/images/main/home/kv3.jpg"
+  },
+  {
+    "roomName": "グループB",
+    "mostRecentMessage": "私も〇〇好きです",
+    "profileImageURL": "https://animeanime.jp/imgs/slider/526911.jpg"
+  },
+  {
+    "roomName": "グループC",
+    "mostRecentMessage": "私も〇〇好きです",
+    "profileImageURL": "https://anime-jam.com/images/mv04.jpg"
+  },
+  {
+    "roomName": "グループD",
+    "mostRecentMessage": "私も〇〇好きです",
+    "profileImageURL": "https://www.tbs.co.jp/anime/5hanayome/img/ogp.jpg"
+  },
+  {
+    "roomName": "グループE",
+    "mostRecentMessage": "私も〇〇好きです",
+    "profileImageURL":
+        "https://kimetsu.com/anime/assets_portal/img/bnr_tv_mugen.jpg"
+  },
+  {
+    "roomName": "グループF",
+    "mostRecentMessage": "私も〇〇好きです",
+    "profileImageURL":
+        "https://img2.animatetimes.com/2020/10/627a3105695b6_72a539b218f44a96c0e41ee1ef98fb7c.jpg"
+  }
+];

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -55,7 +55,7 @@ class AppPages {
       binding: ProfileBinding(),
     ),
     GetPage(
-      name: _Paths.talk_room,
+      name: _Paths.talkRoom,
       page: () => const TalkRoomView(),
       binding: TalkRoomBinding(),
     ),

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -12,6 +12,8 @@ import '../components/pages/mypage/bindings/mypage_binding.dart';
 import '../components/pages/mypage/views/mypage_view.dart';
 import '../components/pages/profile/bindings/profile_binding.dart';
 import '../components/pages/profile/views/profile_view.dart';
+import '../components/pages/talk_room/bindings/talk_room_binding.dart';
+import '../components/pages/talk_room/views/talk_room_view.dart';
 
 part 'app_routes.dart';
 
@@ -51,6 +53,11 @@ class AppPages {
       name: _Paths.profile,
       page: () => const ProfileView(),
       binding: ProfileBinding(),
+    ),
+    GetPage(
+      name: _Paths.talk_room,
+      page: () => const TalkRoomView(),
+      binding: TalkRoomBinding(),
     ),
   ];
 }

--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -9,7 +9,7 @@ abstract class Routes {
   static const mypage = _Paths.mypage;
   static const createChatGroup = _Paths.createChatGroup;
   static const profile = _Paths.profile;
-  static const talk_room = _Paths.talk_room;
+  static const talkRoom = _Paths.talkRoom;
 }
 
 abstract class _Paths {
@@ -20,5 +20,5 @@ abstract class _Paths {
   static const mypage = '/mypage';
   static const createChatGroup = '/create-chat-group';
   static const profile = '/profile';
-  static const talk_room = '/talk-room';
+  static const talkRoom = '/talk-room';
 }

--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -9,6 +9,7 @@ abstract class Routes {
   static const mypage = _Paths.mypage;
   static const createChatGroup = _Paths.createChatGroup;
   static const profile = _Paths.profile;
+  static const talk_room = _Paths.talk_room;
 }
 
 abstract class _Paths {
@@ -19,4 +20,5 @@ abstract class _Paths {
   static const mypage = '/mypage';
   static const createChatGroup = '/create-chat-group';
   static const profile = '/profile';
+  static const talk_room = '/talk-room';
 }


### PR DESCRIPTION
# ✨ What's done

- [x] トークTOP画面のカードからトークルーム画面への遷移処理を追加
<img src="https://user-images.githubusercontent.com/49933865/202285169-0c969821-84f0-441e-9cf4-4fe0020a59ae.png" width=250><img src="https://user-images.githubusercontent.com/49933865/202284939-b23b3793-590b-4169-8c6e-904935ad09e8.png" width=250>

# 🚩 What's not done

- [x] 特になし

# ✅ Test

- [x] androidエミュレータで動作確認

# 🔧 補足、備考

- その他特になし

# 🔀 マージ条件

- [x] レビューを通過する
- [ ] セルフマージする