### PR TITLE
FC-131 TOPに戻るボタンを実装する

### DIFF
--- a/lib/app/components/pages/home/controllers/home_controller.dart
+++ b/lib/app/components/pages/home/controllers/home_controller.dart
@@ -9,7 +9,7 @@ class HomeController extends GetxController {
   // final RxList<UserCardData> userCardDataList = userCardList.obs;
   final RxList<UserCardData> userCardDataList = <UserCardData>[].obs;
   final RefreshController refreshController = RefreshController();
-  final RxBool needTopToScroll = false.obs;
+  final RxBool needScrollToTop = false.obs;
 
   final scrollController = ScrollController();
 

--- a/lib/app/components/pages/home/controllers/home_controller.dart
+++ b/lib/app/components/pages/home/controllers/home_controller.dart
@@ -1,5 +1,6 @@
 import 'package:favoritism_communication/app/components/organisms/user_card.dart';
 import 'package:favoritism_communication/app/dummy_data/user_card_dummy_data.dart';
+import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
@@ -8,6 +9,9 @@ class HomeController extends GetxController {
   // final RxList<UserCardData> userCardDataList = userCardList.obs;
   final RxList<UserCardData> userCardDataList = <UserCardData>[].obs;
   final RefreshController refreshController = RefreshController();
+  final RxBool needTopToScroll = false.obs;
+
+  final scrollController = ScrollController();
 
   @override
   void onInit() {

--- a/lib/app/components/pages/home/views/home_view.dart
+++ b/lib/app/components/pages/home/views/home_view.dart
@@ -36,73 +36,67 @@ class HomeView extends GetView<HomeController> {
             }),
             child: Padding(
               padding: const EdgeInsets.all(8.0),
-              child: CustomSmartRefresher(
-                refreshController: controller.refreshController,
-                enablePullDown: false,
-                enablePullUp: true,
-                onLoading: () {
-                  controller.onLoading();
-                },
-                child: SingleChildScrollView(
-                  controller: controller.scrollController,
-                  child: Obx(
-                    () => controller.userCardDataList.isNotEmpty
-                        ? ListView.separated(
-                            controller: controller.scrollController,
-                            // physics: const NeverScrollableScrollPhysics(),
-                            shrinkWrap: true,
-                            itemCount: controller.userCardDataList.length,
-                            itemBuilder: (context, index) {
-                              final UserCardData userCardData =
-                                  controller.userCardDataList[index];
-                              return UserCard(
-                                userCardData: userCardData,
-                                followAction: Obx(
-                                  () => controller
-                                          .userCardDataList[index].isFollowed
-                                      ? FollowButton(
-                                          onPressed: () {
-                                            debugPrint("scrollToTop!!");
-                                            controller.scrollController
-                                                .jumpTo(0);
-                                            controller.unFollow(userCardData);
-                                          },
-                                          backgroundColor: Colors.blueAccent,
-                                          foregroundColor: Colors.white,
-                                          isFollowed: userCardData.isFollowed,
-                                        )
-                                      : FollowButton(
-                                          onPressed: () {
-                                            controller.follow(userCardData);
-                                          },
-                                          backgroundColor: Colors.white,
-                                          foregroundColor: Colors.blueAccent,
-                                          isFollowed: userCardData.isFollowed,
-                                        ),
-                                ),
-                                onTapped: () {
-                                  // todo NestedNavigationの実装ができたら画面遷移方法を変更する
-                                  Get.toNamed(Routes.profile,
-                                      arguments: [userCardData.userName]);
-                                },
-                              );
-                            },
-                            separatorBuilder: (context, index) =>
-                                const SizedBox(height: 10),
-                          )
-                        : Column(
-                            children: const [
-                              SizedBox(height: 30),
-                              Center(
-                                child: Text(
-                                  '検索結果がありません',
-                                  style: TextStyle(fontSize: 18),
-                                ),
+              child: Obx(
+                () => controller.userCardDataList.isNotEmpty
+                    ? CustomSmartRefresher(
+                        refreshController: controller.refreshController,
+                        enablePullDown: false,
+                        enablePullUp: true,
+                        onLoading: () {
+                          controller.onLoading();
+                        },
+                        child: ListView.separated(
+                          controller: controller.scrollController,
+                          shrinkWrap: true,
+                          itemCount: controller.userCardDataList.length,
+                          itemBuilder: (context, index) {
+                            final UserCardData userCardData =
+                                controller.userCardDataList[index];
+                            return UserCard(
+                              userCardData: userCardData,
+                              followAction: Obx(
+                                () => controller
+                                        .userCardDataList[index].isFollowed
+                                    ? FollowButton(
+                                        onPressed: () {
+                                          debugPrint("scrollToTop!!");
+                                          controller.scrollController.jumpTo(0);
+                                          controller.unFollow(userCardData);
+                                        },
+                                        backgroundColor: Colors.blueAccent,
+                                        foregroundColor: Colors.white,
+                                        isFollowed: userCardData.isFollowed,
+                                      )
+                                    : FollowButton(
+                                        onPressed: () {
+                                          controller.follow(userCardData);
+                                        },
+                                        backgroundColor: Colors.white,
+                                        foregroundColor: Colors.blueAccent,
+                                        isFollowed: userCardData.isFollowed,
+                                      ),
                               ),
-                            ],
+                              onTapped: () {
+                                // todo NestedNavigationの実装ができたら画面遷移方法を変更する
+                                Get.toNamed(Routes.profile,
+                                    arguments: [userCardData.userName]);
+                              },
+                            );
+                          },
+                          separatorBuilder: (context, index) =>
+                              const SizedBox(height: 10),
+                        ))
+                    : Column(
+                        children: const [
+                          SizedBox(height: 30),
+                          Center(
+                            child: Text(
+                              '検索結果がありません',
+                              style: TextStyle(fontSize: 18),
+                            ),
                           ),
-                  ),
-                ),
+                        ],
+                      ),
               ),
             ),
           ),

--- a/lib/app/components/pages/home/views/home_view.dart
+++ b/lib/app/components/pages/home/views/home_view.dart
@@ -48,7 +48,8 @@ class HomeView extends GetView<HomeController> {
                   child: Obx(
                     () => controller.userCardDataList.isNotEmpty
                         ? ListView.separated(
-                            physics: const NeverScrollableScrollPhysics(),
+                            controller: controller.scrollController,
+                            // physics: const NeverScrollableScrollPhysics(),
                             shrinkWrap: true,
                             itemCount: controller.userCardDataList.length,
                             itemBuilder: (context, index) {
@@ -61,6 +62,9 @@ class HomeView extends GetView<HomeController> {
                                           .userCardDataList[index].isFollowed
                                       ? FollowButton(
                                           onPressed: () {
+                                            debugPrint("scrollToTop!!");
+                                            controller.scrollController
+                                                .jumpTo(0);
                                             controller.unFollow(userCardData);
                                           },
                                           backgroundColor: Colors.blueAccent,
@@ -115,9 +119,9 @@ class HomeView extends GetView<HomeController> {
                     elevation: 0,
                   ),
                   onPressed: () {
-                    debugPrint(
-                        "scrollTo ${controller.scrollController.position.pixels}");
-                    controller.scrollController.jumpTo(0.0);
+                    // debugPrint(
+                    //     "scrollTo ${controller.scrollController.position.pixels}");
+                    controller.scrollController.jumpTo(0);
                     // controller.scrollController.animateTo(0,
                     //     duration: const Duration(seconds: 1),
                     //     curve: Curves.linear);

--- a/lib/app/components/pages/home/views/home_view.dart
+++ b/lib/app/components/pages/home/views/home_view.dart
@@ -26,7 +26,7 @@ class HomeView extends GetView<HomeController> {
               // スクロール位置が2000pxより下になったらTOPに戻るボタンを表示
               if (notification.metrics.pixels > 2000) {
                 controller.needScrollToTop(true);
-                // スクロール停止後、2秒経過したらボタンを非表示にする
+                // スクロール停止後、指定秒を経過したらボタンを非表示にする
                 Future.delayed(const Duration(seconds: 3),
                     () => {controller.needScrollToTop(false)});
               } else {

--- a/lib/app/components/pages/home/views/home_view.dart
+++ b/lib/app/components/pages/home/views/home_view.dart
@@ -3,7 +3,6 @@ import 'package:favoritism_communication/app/components/organisms/organisms.dart
 import 'package:favoritism_communication/app/components/templates/custom_smartrefresher.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-// import 'package:pull_to_refresh/pull_to_refresh.dart';
 import '../../../../routes/app_pages.dart';
 import '../controllers/home_controller.dart';
 
@@ -23,7 +22,6 @@ class HomeView extends GetView<HomeController> {
           NotificationListener<ScrollNotification>(
             onNotification: ((notification) {
               // スクロール位置が2000pxより下になったらTOPに戻るボタンを表示
-              debugPrint("offset ${notification.metrics.pixels}");
               if (notification.metrics.pixels > 2000) {
                 controller.needScrollToTop(true);
                 // スクロール停止後、2秒経過したらボタンを非表示にする
@@ -114,12 +112,7 @@ class HomeView extends GetView<HomeController> {
                     elevation: 0,
                   ),
                   onPressed: () {
-                    // debugPrint(
-                    //     "scrollTo ${controller.scrollController.position.pixels}");
                     controller.scrollController.jumpTo(0);
-                    // controller.scrollController.animateTo(0,
-                    //     duration: const Duration(seconds: 1),
-                    //     curve: Curves.linear);
                   },
                   child: const Text('TOPに戻る'),
                 ),

--- a/lib/app/components/pages/home/views/home_view.dart
+++ b/lib/app/components/pages/home/views/home_view.dart
@@ -130,7 +130,9 @@ class HomeView extends GetView<HomeController> {
           ),
           Obx(() => Visibility(
               visible: controller.needScrollToTop.value,
-              child: Center(
+              child: Positioned(
+                bottom: 25,
+                left: Get.width / 3,
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
                     fixedSize:

--- a/lib/app/components/pages/home/views/home_view.dart
+++ b/lib/app/components/pages/home/views/home_view.dart
@@ -23,14 +23,14 @@ class HomeView extends GetView<HomeController> {
           NotificationListener<ScrollNotification>(
             onNotification: ((notification) {
               // スクロール位置が2000pxより下になったらTOPに戻るボタンを表示
-              //controller.scrollOffset = notification.metrics.pixels;
+              debugPrint("offset ${notification.metrics.pixels}");
               if (notification.metrics.pixels > 2000) {
-                controller.needTopToScroll(true);
+                controller.needScrollToTop(true);
                 // スクロール停止後、2秒経過したらボタンを非表示にする
-                Future.delayed(const Duration(seconds: 2),
-                    () => {controller.needTopToScroll(false)});
+                Future.delayed(const Duration(seconds: 3),
+                    () => {controller.needScrollToTop(false)});
               } else {
-                controller.needTopToScroll(false);
+                controller.needScrollToTop(false);
               }
               return false;
             }),
@@ -103,7 +103,7 @@ class HomeView extends GetView<HomeController> {
             ),
           ),
           Obx(() => Visibility(
-              visible: controller.needTopToScroll.value,
+              visible: controller.needScrollToTop.value,
               child: Center(
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
@@ -115,14 +115,12 @@ class HomeView extends GetView<HomeController> {
                     elevation: 0,
                   ),
                   onPressed: () {
-                    // debugPrint("jumpto offset=${controller.scrollOffset}");
-                    // controller.listViewScrollController
-                    // .jumpTo(-controller.scrollOffset);
                     debugPrint(
                         "scrollTo ${controller.scrollController.position.pixels}");
-                    controller.scrollController.animateTo(0,
-                        duration: const Duration(seconds: 1),
-                        curve: Curves.linear);
+                    controller.scrollController.jumpTo(0.0);
+                    // controller.scrollController.animateTo(0,
+                    //     duration: const Duration(seconds: 1),
+                    //     curve: Curves.linear);
                   },
                   child: const Text('TOPに戻る'),
                 ),

--- a/lib/app/components/pages/home/views/home_view.dart
+++ b/lib/app/components/pages/home/views/home_view.dart
@@ -40,6 +40,7 @@ class HomeView extends GetView<HomeController> {
                 () => controller.userCardDataList.isNotEmpty
                     ? CustomSmartRefresher(
                         refreshController: controller.refreshController,
+                        scrollController: controller.scrollController,
                         enablePullDown: false,
                         enablePullUp: true,
                         onLoading: () {

--- a/lib/app/components/pages/home/views/home_view.dart
+++ b/lib/app/components/pages/home/views/home_view.dart
@@ -113,7 +113,8 @@ class HomeView extends GetView<HomeController> {
                           },
                           separatorBuilder: (context, index) =>
                               const SizedBox(height: 10),
-                        ))
+                        ),
+                      )
                     : Column(
                         children: const [
                           SizedBox(height: 30),
@@ -128,7 +129,8 @@ class HomeView extends GetView<HomeController> {
               ),
             ),
           ),
-          Obx(() => Visibility(
+          Obx(
+            () => Visibility(
               visible: controller.needScrollToTop.value,
               child: Positioned(
                 bottom: 25,
@@ -147,7 +149,9 @@ class HomeView extends GetView<HomeController> {
                   },
                   child: const Text('TOPに戻る'),
                 ),
-              )))
+              ),
+            ),
+          )
         ],
       ),
     );

--- a/lib/app/components/pages/home/views/home_view.dart
+++ b/lib/app/components/pages/home/views/home_view.dart
@@ -20,87 +20,113 @@ class HomeView extends GetView<HomeController> {
       ),
       body: Stack(
         children: [
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: CustomSmartRefresher(
-              refreshController: controller.refreshController,
-              enablePullDown: false,
-              enablePullUp: true,
-              onLoading: () {
-                controller.onLoading();
-              },
-              child: SingleChildScrollView(
-                child: Obx(
-                  () => controller.userCardDataList.isNotEmpty
-                      ? ListView.separated(
-                          physics: const NeverScrollableScrollPhysics(),
-                          shrinkWrap: true,
-                          itemCount: controller.userCardDataList.length,
-                          itemBuilder: (context, index) {
-                            final UserCardData userCardData =
-                                controller.userCardDataList[index];
-                            return UserCard(
-                              userCardData: userCardData,
-                              followAction: Obx(
-                                () => controller
-                                        .userCardDataList[index].isFollowed
-                                    ? FollowButton(
-                                        onPressed: () {
-                                          controller.unFollow(userCardData);
-                                        },
-                                        backgroundColor: Colors.blueAccent,
-                                        foregroundColor: Colors.white,
-                                        isFollowed: userCardData.isFollowed,
-                                      )
-                                    : FollowButton(
-                                        onPressed: () {
-                                          controller.follow(userCardData);
-                                        },
-                                        backgroundColor: Colors.white,
-                                        foregroundColor: Colors.blueAccent,
-                                        isFollowed: userCardData.isFollowed,
-                                      ),
+          NotificationListener<ScrollNotification>(
+            onNotification: ((notification) {
+              // スクロール位置が2000pxより下になったらTOPに戻るボタンを表示
+              //controller.scrollOffset = notification.metrics.pixels;
+              if (notification.metrics.pixels > 2000) {
+                controller.needTopToScroll(true);
+                // スクロール停止後、2秒経過したらボタンを非表示にする
+                Future.delayed(const Duration(seconds: 2),
+                    () => {controller.needTopToScroll(false)});
+              } else {
+                controller.needTopToScroll(false);
+              }
+              return false;
+            }),
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: CustomSmartRefresher(
+                refreshController: controller.refreshController,
+                enablePullDown: false,
+                enablePullUp: true,
+                onLoading: () {
+                  controller.onLoading();
+                },
+                child: SingleChildScrollView(
+                  controller: controller.scrollController,
+                  child: Obx(
+                    () => controller.userCardDataList.isNotEmpty
+                        ? ListView.separated(
+                            physics: const NeverScrollableScrollPhysics(),
+                            shrinkWrap: true,
+                            itemCount: controller.userCardDataList.length,
+                            itemBuilder: (context, index) {
+                              final UserCardData userCardData =
+                                  controller.userCardDataList[index];
+                              return UserCard(
+                                userCardData: userCardData,
+                                followAction: Obx(
+                                  () => controller
+                                          .userCardDataList[index].isFollowed
+                                      ? FollowButton(
+                                          onPressed: () {
+                                            controller.unFollow(userCardData);
+                                          },
+                                          backgroundColor: Colors.blueAccent,
+                                          foregroundColor: Colors.white,
+                                          isFollowed: userCardData.isFollowed,
+                                        )
+                                      : FollowButton(
+                                          onPressed: () {
+                                            controller.follow(userCardData);
+                                          },
+                                          backgroundColor: Colors.white,
+                                          foregroundColor: Colors.blueAccent,
+                                          isFollowed: userCardData.isFollowed,
+                                        ),
+                                ),
+                                onTapped: () {
+                                  // todo NestedNavigationの実装ができたら画面遷移方法を変更する
+                                  Get.toNamed(Routes.profile,
+                                      arguments: [userCardData.userName]);
+                                },
+                              );
+                            },
+                            separatorBuilder: (context, index) =>
+                                const SizedBox(height: 10),
+                          )
+                        : Column(
+                            children: const [
+                              SizedBox(height: 30),
+                              Center(
+                                child: Text(
+                                  '検索結果がありません',
+                                  style: TextStyle(fontSize: 18),
+                                ),
                               ),
-                              onTapped: () {
-                                // todo NestedNavigationの実装ができたら画面遷移方法を変更する
-                                Get.toNamed(Routes.profile,
-                                    arguments: [userCardData.userName]);
-                              },
-                            );
-                          },
-                          separatorBuilder: (context, index) =>
-                              const SizedBox(height: 10),
-                        )
-                      : Column(
-                          children: const [
-                            SizedBox(height: 30),
-                            Center(
-                              child: Text(
-                                '検索結果がありません',
-                                style: TextStyle(fontSize: 18),
-                              ),
-                            ),
-                          ],
-                        ),
+                            ],
+                          ),
+                  ),
                 ),
               ),
             ),
           ),
-          Center(
-            child: ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                fixedSize: Size(MediaQuery.of(context).size.width * 0.3, 25),
-                backgroundColor: const Color.fromRGBO(236, 188, 179, 1),
-                foregroundColor: Colors.white,
-                shape: const StadiumBorder(),
-                elevation: 0,
-              ),
-              onPressed: () {
-                // todo トップに戻る
-              },
-              child: const Text('TOPに戻る'),
-            ),
-          )
+          Obx(() => Visibility(
+              visible: controller.needTopToScroll.value,
+              child: Center(
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    fixedSize:
+                        Size(MediaQuery.of(context).size.width * 0.3, 25),
+                    backgroundColor: const Color.fromRGBO(236, 188, 179, 1),
+                    foregroundColor: Colors.white,
+                    shape: const StadiumBorder(),
+                    elevation: 0,
+                  ),
+                  onPressed: () {
+                    // debugPrint("jumpto offset=${controller.scrollOffset}");
+                    // controller.listViewScrollController
+                    // .jumpTo(-controller.scrollOffset);
+                    debugPrint(
+                        "scrollTo ${controller.scrollController.position.pixels}");
+                    controller.scrollController.animateTo(0,
+                        duration: const Duration(seconds: 1),
+                        curve: Curves.linear);
+                  },
+                  child: const Text('TOPに戻る'),
+                ),
+              )))
         ],
       ),
     );

--- a/lib/app/components/templates/custom_smartrefresher.dart
+++ b/lib/app/components/templates/custom_smartrefresher.dart
@@ -21,15 +21,13 @@ class CustomSmartRefresher extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scrollbar(
-      child: SmartRefresher(
-        controller: refreshController,
-        enablePullDown: false,
-        enablePullUp: true,
-        onRefresh: () => onRefresh?.call(),
-        onLoading: () => onLoading?.call(),
-        child: child,
-      ),
+    return SmartRefresher(
+      controller: refreshController,
+      enablePullDown: false,
+      enablePullUp: true,
+      onRefresh: () => onRefresh?.call(),
+      onLoading: () => onLoading?.call(),
+      child: child,
     );
   }
 }

--- a/lib/app/components/templates/custom_smartrefresher.dart
+++ b/lib/app/components/templates/custom_smartrefresher.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 class CustomSmartRefresher extends StatelessWidget {
-  CustomSmartRefresher({
+  const CustomSmartRefresher({
     super.key,
     required this.refreshController,
-    this.scrollController = null,
+    this.scrollController,
     required this.enablePullDown,
     required this.enablePullUp,
     required this.child,

--- a/lib/app/components/templates/custom_smartrefresher.dart
+++ b/lib/app/components/templates/custom_smartrefresher.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 class CustomSmartRefresher extends StatelessWidget {
-  const CustomSmartRefresher({
+  CustomSmartRefresher({
     super.key,
     required this.refreshController,
+    this.scrollController = null,
     required this.enablePullDown,
     required this.enablePullUp,
     required this.child,
@@ -13,6 +14,7 @@ class CustomSmartRefresher extends StatelessWidget {
   });
 
   final RefreshController refreshController;
+  final ScrollController? scrollController;
   final bool enablePullDown;
   final bool enablePullUp;
   final VoidCallback? onLoading;
@@ -21,13 +23,15 @@ class CustomSmartRefresher extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SmartRefresher(
-      controller: refreshController,
-      enablePullDown: false,
-      enablePullUp: true,
-      onRefresh: () => onRefresh?.call(),
-      onLoading: () => onLoading?.call(),
-      child: child,
-    );
+    return Scrollbar(
+        controller: scrollController,
+        child: SmartRefresher(
+          controller: refreshController,
+          enablePullDown: false,
+          enablePullUp: true,
+          onRefresh: () => onRefresh?.call(),
+          onLoading: () => onLoading?.call(),
+          child: child,
+        ));
   }
 }


### PR DESCRIPTION
# ✨ What's done

- [x] Topへ戻るボタンの表示・押下時アクションを実装
  - リストビューの表示位置が2000pxより下かつスクロール実行から3秒以内の場合にTOPへ戻るボタンを表示
  - ボタン押下時にリストビューの先頭位置を表示する
- [x] SingleChildScrollViewを削除（ListViewの役割が重複していたため）
- [x] CustomSmartRefresherのScrollBarウィジェットのcontrollerにScrollControllerを設定
  - TOPへ戻る操作を実現するために必要な対応

# ✅ Test

- [x] iOS & Android のシミュレータで動作を確認
- [x] 修正対象のCustomSmartRefresherを利用しているトーク画面のメンバー、グループの表示・動作が修正前後で差異がないことを確認

# 🔧 補足、備考

https://user-images.githubusercontent.com/3205581/204137957-ad3e4942-1168-4d01-9b04-ec11f1759563.mov

# 🔀 マージ条件

- [ ] レビューを通過する
- [ ] セルフマージする