### PR TITLE
✨画面下部のナビゲーションバーに検索メニューを追加

### DIFF
--- a/.github/workflows/flutter-linter.yml
+++ b/.github/workflows/flutter-linter.yml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.3.4'
           channel: 'stable'
       
       - name: Check flutter version

--- a/lib/app/components/organisms/dashbord_items.dart
+++ b/lib/app/components/organisms/dashbord_items.dart
@@ -1,0 +1,46 @@
+import 'package:favoritism_communication/app/components/pages/tab_root/tab_root_view.dart';
+import 'package:flutter/material.dart';
+import 'package:favoritism_communication/app/routes/app_pages.dart';
+import 'package:flutter/cupertino.dart';
+
+
+class NavigationInfo {
+  const NavigationInfo({
+    required this.icon,
+    required this.initialRoot,
+    required this.label,
+  });
+  final IconData icon;
+  final String initialRoot;
+  final String label;
+
+  static final List<NavigationInfo> infos = [
+    const NavigationInfo(
+      icon: CupertinoIcons.home,
+      initialRoot: Routes.home,
+      label: 'ホーム',
+    ),
+    const NavigationInfo(
+      icon: CupertinoIcons.search,
+      initialRoot: Routes.search,
+      label: 'さがす',
+    ),
+    const NavigationInfo(
+      icon: CupertinoIcons.chat_bubble,
+      initialRoot: Routes.chat,
+      label: 'トーク',
+    ),
+    const NavigationInfo(
+      icon: CupertinoIcons.person,
+      initialRoot: Routes.mypage,
+      label: 'プロフィール',
+    ),
+  ];
+}
+
+List<Widget> tabRootViews = NavigationInfo.infos
+    .map((e) => TabRootView(initialRoot: e.initialRoot))
+    .toList();
+List<BottomNavigationBarItem> bottomBarItems = NavigationInfo.infos
+    .map((e) => BottomNavigationBarItem(icon: Icon(e.icon), label: e.label))
+    .toList();

--- a/lib/app/components/organisms/dashbord_items.dart
+++ b/lib/app/components/organisms/dashbord_items.dart
@@ -12,34 +12,34 @@ class NavigationInfo {
   final IconData icon;
   final String initialRoot;
   final String label;
-
-  static final List<NavigationInfo> infos = [
-    const NavigationInfo(
-      icon: CupertinoIcons.home,
-      initialRoot: Routes.home,
-      label: 'ホーム',
-    ),
-    const NavigationInfo(
-      icon: CupertinoIcons.search,
-      initialRoot: Routes.search,
-      label: 'さがす',
-    ),
-    const NavigationInfo(
-      icon: CupertinoIcons.chat_bubble,
-      initialRoot: Routes.chat,
-      label: 'トーク',
-    ),
-    const NavigationInfo(
-      icon: CupertinoIcons.person,
-      initialRoot: Routes.mypage,
-      label: 'プロフィール',
-    ),
-  ];
 }
 
-List<Widget> tabRootViews = NavigationInfo.infos
+const List<NavigationInfo> _navigationInfos = [
+  NavigationInfo(
+    icon: CupertinoIcons.home,
+    initialRoot: Routes.home,
+    label: 'ホーム',
+  ),
+  NavigationInfo(
+    icon: CupertinoIcons.search,
+    initialRoot: Routes.search,
+    label: 'さがす',
+  ),
+  NavigationInfo(
+    icon: CupertinoIcons.chat_bubble,
+    initialRoot: Routes.chat,
+    label: 'トーク',
+  ),
+  NavigationInfo(
+    icon: CupertinoIcons.person,
+    initialRoot: Routes.mypage,
+    label: 'プロフィール',
+  ),
+];
+
+List<Widget> tabRootViews = _navigationInfos
     .map((e) => TabRootView(initialRoot: e.initialRoot))
     .toList();
-List<BottomNavigationBarItem> bottomBarItems = NavigationInfo.infos
+List<BottomNavigationBarItem> bottomBarItems = _navigationInfos
     .map((e) => BottomNavigationBarItem(icon: Icon(e.icon), label: e.label))
     .toList();

--- a/lib/app/components/organisms/dashbord_items.dart
+++ b/lib/app/components/organisms/dashbord_items.dart
@@ -1,5 +1,4 @@
 import 'package:favoritism_communication/app/components/pages/tab_root/tab_root_view.dart';
-import 'package:flutter/material.dart';
 import 'package:favoritism_communication/app/routes/app_pages.dart';
 import 'package:flutter/cupertino.dart';
 

--- a/lib/app/components/pages/dashboard/controllers/dashboard_controller.dart
+++ b/lib/app/components/pages/dashboard/controllers/dashboard_controller.dart
@@ -1,13 +1,39 @@
 import 'package:favoritism_communication/app/services/services.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:favoritism_communication/app/utils/ad_util.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:favoritism_communication/app/routes/app_pages.dart';
+import 'package:favoritism_communication/app/components/pages/search/views/search_view.dart';
+
+class NavigationInfo{
+  const NavigationInfo({
+    required this.icon,
+    required this.initialRoot,
+    required this.label,
+    required this.isModal,
+  });
+
+  final IconData icon;
+  final String initialRoot;
+  final String label;
+  final bool isModal;
+}
+
 
 class DashboardController extends GetxController {
   final TabService tabService = Get.find();
   BannerAd? _ad;
   final isShowAd = false.obs;
+
+  final List<NavigationInfo> navigationInfo = const [
+    NavigationInfo(icon: CupertinoIcons.home, initialRoot: Routes.home, label: 'ホーム', isModal: false),
+    NavigationInfo(icon: CupertinoIcons.search, initialRoot: Routes.search, label: 'さがす', isModal: true),
+    NavigationInfo(icon: CupertinoIcons.chat_bubble, initialRoot: Routes.chat, label: 'トーク', isModal: false),
+    NavigationInfo(icon: CupertinoIcons.person, initialRoot: Routes.mypage, label: 'プロフィール', isModal: false),
+  ];
 
   BannerAd? getAd() {
     return _ad;
@@ -41,4 +67,20 @@ class DashboardController extends GetxController {
       _ad!.dispose();
     }
   }
+
+  void changeIndex(int index) {
+    if(navigationInfo[index].isModal){
+      openDialog();
+    }
+    else{
+      tabService.changeIndex(index);
+    }
+  }
+
+  void openDialog() {
+    Get.dialog(
+      const SearchView(),
+    );
+  }
+
 }

--- a/lib/app/components/pages/dashboard/controllers/dashboard_controller.dart
+++ b/lib/app/components/pages/dashboard/controllers/dashboard_controller.dart
@@ -3,37 +3,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:favoritism_communication/app/utils/ad_util.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
-import 'package:favoritism_communication/app/routes/app_pages.dart';
-import 'package:favoritism_communication/app/components/pages/search/views/search_view.dart';
-
-class NavigationInfo{
-  const NavigationInfo({
-    required this.icon,
-    required this.initialRoot,
-    required this.label,
-    required this.isModal,
-    this.modalWindow,
-  });
-
-  final IconData icon;
-  final String initialRoot;
-  final String label;
-  final bool isModal;
-  final Widget? modalWindow;
-}
 
 
 class DashboardController extends GetxController {
   final TabService tabService = Get.find();
   BannerAd? _ad;
   final isShowAd = false.obs;
-
-  final List<NavigationInfo> navigationInfo = const [
-    NavigationInfo(icon: CupertinoIcons.home, initialRoot: Routes.home, label: 'ホーム', isModal: false),
-    NavigationInfo(icon: CupertinoIcons.search, initialRoot: Routes.search, label: 'さがす', isModal: true, modalWindow: SearchView()),
-    NavigationInfo(icon: CupertinoIcons.chat_bubble, initialRoot: Routes.chat, label: 'トーク', isModal: false),
-    NavigationInfo(icon: CupertinoIcons.person, initialRoot: Routes.mypage, label: 'プロフィール', isModal: false),
-  ];
 
   BannerAd? getAd() {
     return _ad;
@@ -65,16 +40,6 @@ class DashboardController extends GetxController {
     super.onClose();
     if (_ad != null) {
       _ad!.dispose();
-    }
-  }
-
-  void changeIndex(int index) {
-    // モーダルの場合
-    if(navigationInfo[index].isModal){
-      Get.dialog(navigationInfo[index].modalWindow!); // ダイアログで表示
-    }
-    else{
-      tabService.changeIndex(index);  // インデックスを変更
     }
   }
 }

--- a/lib/app/components/pages/dashboard/controllers/dashboard_controller.dart
+++ b/lib/app/components/pages/dashboard/controllers/dashboard_controller.dart
@@ -1,7 +1,5 @@
 import 'package:favoritism_communication/app/services/services.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:favoritism_communication/app/utils/ad_util.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
@@ -14,12 +12,14 @@ class NavigationInfo{
     required this.initialRoot,
     required this.label,
     required this.isModal,
+    this.modalWindow,
   });
 
   final IconData icon;
   final String initialRoot;
   final String label;
   final bool isModal;
+  final Widget? modalWindow;
 }
 
 
@@ -30,7 +30,7 @@ class DashboardController extends GetxController {
 
   final List<NavigationInfo> navigationInfo = const [
     NavigationInfo(icon: CupertinoIcons.home, initialRoot: Routes.home, label: 'ホーム', isModal: false),
-    NavigationInfo(icon: CupertinoIcons.search, initialRoot: Routes.search, label: 'さがす', isModal: true),
+    NavigationInfo(icon: CupertinoIcons.search, initialRoot: Routes.search, label: 'さがす', isModal: true, modalWindow: SearchView()),
     NavigationInfo(icon: CupertinoIcons.chat_bubble, initialRoot: Routes.chat, label: 'トーク', isModal: false),
     NavigationInfo(icon: CupertinoIcons.person, initialRoot: Routes.mypage, label: 'プロフィール', isModal: false),
   ];
@@ -69,18 +69,12 @@ class DashboardController extends GetxController {
   }
 
   void changeIndex(int index) {
+    // モーダルの場合
     if(navigationInfo[index].isModal){
-      openDialog();
+      Get.dialog(navigationInfo[index].modalWindow!); // ダイアログで表示
     }
     else{
-      tabService.changeIndex(index);
+      tabService.changeIndex(index);  // インデックスを変更
     }
   }
-
-  void openDialog() {
-    Get.dialog(
-      const SearchView(),
-    );
-  }
-
 }

--- a/lib/app/components/pages/dashboard/views/dashboard_view.dart
+++ b/lib/app/components/pages/dashboard/views/dashboard_view.dart
@@ -1,7 +1,5 @@
 import 'package:favoritism_communication/app/components/pages/tab_root/tab_root_view.dart';
-import 'package:favoritism_communication/app/routes/app_pages.dart';
 import 'package:favoritism_communication/app/styles/styles.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/dashboard_controller.dart';

--- a/lib/app/components/pages/dashboard/views/dashboard_view.dart
+++ b/lib/app/components/pages/dashboard/views/dashboard_view.dart
@@ -19,12 +19,9 @@ class DashboardView extends GetView<DashboardController> {
             child: Obx(
               () => IndexedStack(
                 index: controller.tabService.tabIndex.value,
-                children: const [
-                  TabRootView(initialRoot: Routes.home),
-                  TabRootView(initialRoot: Routes.search),
-                  TabRootView(initialRoot: Routes.chat),
-                  TabRootView(initialRoot: Routes.mypage)
-                ],
+                children: controller.navigationInfo.map((info) =>
+                    TabRootView(initialRoot: info.initialRoot)
+                ).toList(),
               ),
             ),
           ),
@@ -45,25 +42,17 @@ class DashboardView extends GetView<DashboardController> {
       ),
       bottomNavigationBar: Obx(
         () => BottomNavigationBar(
-          onTap: controller.tabService.changeIndex,
+          onTap: controller.changeIndex,
           currentIndex: controller.tabService.tabIndex.value,
           unselectedItemColor: colorDashboardUnselectedItem,
           selectedItemColor: colorDashboardSelectedItem,
           type: BottomNavigationBarType.fixed,
-          items: const <BottomNavigationBarItem>[
+          items: controller.navigationInfo.map((info) =>
             BottomNavigationBarItem(
-              icon: Icon(CupertinoIcons.home),
-              label: 'ホーム',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(CupertinoIcons.chat_bubble),
-              label: 'トーク',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(CupertinoIcons.person),
-              label: 'プロフィール',
+              icon: Icon(info.icon),
+              label: info.label,
             )
-          ],
+          ).toList(),
         ),
       ),
     );

--- a/lib/app/components/pages/dashboard/views/dashboard_view.dart
+++ b/lib/app/components/pages/dashboard/views/dashboard_view.dart
@@ -1,4 +1,4 @@
-import 'package:favoritism_communication/app/components/pages/tab_root/tab_root_view.dart';
+import 'package:favoritism_communication/app/components/organisms/dashbord_items.dart';
 import 'package:favoritism_communication/app/styles/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -17,9 +17,7 @@ class DashboardView extends GetView<DashboardController> {
             child: Obx(
               () => IndexedStack(
                 index: controller.tabService.tabIndex.value,
-                children: controller.navigationInfo.map((info) =>
-                    TabRootView(initialRoot: info.initialRoot)
-                ).toList(),
+                children: tabRootViews,
               ),
             ),
           ),
@@ -40,17 +38,12 @@ class DashboardView extends GetView<DashboardController> {
       ),
       bottomNavigationBar: Obx(
         () => BottomNavigationBar(
-          onTap: controller.changeIndex,
+          onTap: controller.tabService.changeIndex,
           currentIndex: controller.tabService.tabIndex.value,
           unselectedItemColor: colorDashboardUnselectedItem,
           selectedItemColor: colorDashboardSelectedItem,
           type: BottomNavigationBarType.fixed,
-          items: controller.navigationInfo.map((info) =>
-            BottomNavigationBarItem(
-              icon: Icon(info.icon),
-              label: info.label,
-            )
-          ).toList(),
+          items: bottomBarItems,
         ),
       ),
     );

--- a/lib/app/components/pages/dashboard/views/dashboard_view.dart
+++ b/lib/app/components/pages/dashboard/views/dashboard_view.dart
@@ -21,6 +21,7 @@ class DashboardView extends GetView<DashboardController> {
                 index: controller.tabService.tabIndex.value,
                 children: const [
                   TabRootView(initialRoot: Routes.home),
+                  TabRootView(initialRoot: Routes.search),
                   TabRootView(initialRoot: Routes.chat),
                   TabRootView(initialRoot: Routes.mypage)
                 ],

--- a/lib/app/components/pages/search/bindings/search_binding.dart
+++ b/lib/app/components/pages/search/bindings/search_binding.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../controllers/search_controller.dart';
+
+class SearchBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<SearchController>(
+      () => SearchController(),
+    );
+  }
+}

--- a/lib/app/components/pages/search/controllers/search_controller.dart
+++ b/lib/app/components/pages/search/controllers/search_controller.dart
@@ -1,0 +1,23 @@
+import 'package:get/get.dart';
+
+class SearchController extends GetxController {
+  //TODO: Implement SearchController
+
+  final count = 0.obs;
+  @override
+  void onInit() {
+    super.onInit();
+  }
+
+  @override
+  void onReady() {
+    super.onReady();
+  }
+
+  @override
+  void onClose() {
+    super.onClose();
+  }
+
+  void increment() => count.value++;
+}

--- a/lib/app/components/pages/search/controllers/search_controller.dart
+++ b/lib/app/components/pages/search/controllers/search_controller.dart
@@ -1,23 +1,4 @@
 import 'package:get/get.dart';
 
 class SearchController extends GetxController {
-  //TODO: Implement SearchController
-
-  final count = 0.obs;
-  @override
-  void onInit() {
-    super.onInit();
-  }
-
-  @override
-  void onReady() {
-    super.onReady();
-  }
-
-  @override
-  void onClose() {
-    super.onClose();
-  }
-
-  void increment() => count.value++;
 }

--- a/lib/app/components/pages/search/views/search_view.dart
+++ b/lib/app/components/pages/search/views/search_view.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import 'package:get/get.dart';
+
+import '../controllers/search_controller.dart';
+
+class SearchView extends GetView<SearchController> {
+  const SearchView({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('SearchView'),
+        centerTitle: true,
+      ),
+      body: Center(
+        child: Text(
+          'SearchView is working',
+          style: TextStyle(fontSize: 20),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/components/pages/search/views/search_view.dart
+++ b/lib/app/components/pages/search/views/search_view.dart
@@ -13,7 +13,7 @@ class SearchView extends GetView<SearchController> {
         title: const Text('SearchView'),
         centerTitle: true,
       ),
-      body: Center(
+      body: const Center(
         child: Text(
           'SearchView is working',
           style: TextStyle(fontSize: 20),

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -12,6 +12,8 @@ import '../components/pages/mypage/bindings/mypage_binding.dart';
 import '../components/pages/mypage/views/mypage_view.dart';
 import '../components/pages/profile/bindings/profile_binding.dart';
 import '../components/pages/profile/views/profile_view.dart';
+import '../components/pages/search/bindings/search_binding.dart';
+import '../components/pages/search/views/search_view.dart';
 import '../components/pages/talk_room/bindings/talk_room_binding.dart';
 import '../components/pages/talk_room/views/talk_room_view.dart';
 
@@ -59,6 +61,11 @@ class AppPages {
       name: _Paths.talkRoom,
       page: () => const TalkRoomView(),
       binding: TalkRoomBinding(),
+    ),
+    GetPage(
+      name: _Paths.search,
+      page: () => const SearchView(),
+      binding: SearchBinding(),
     ),
   ];
 }

--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -10,6 +10,7 @@ abstract class Routes {
   static const createChatGroup = _Paths.createChatGroup;
   static const profile = _Paths.profile;
   static const talkRoom = _Paths.talkRoom;
+  static const search = _Paths.search;
 }
 
 abstract class _Paths {
@@ -21,4 +22,5 @@ abstract class _Paths {
   static const createChatGroup = '/create-chat-group';
   static const profile = '/profile';
   static const talkRoom = '/talk-room';
+  static const search = '/search';
 }


### PR DESCRIPTION
# ✨ What's done
対象： FC-198 / FC-185
- [x] 画面下部のナビゲーションバーに検索メニューの追加
- [x] ボタン押下時に検索ウィンドウのダイアログを開く処理を追加

# 🚩 What's not done

- [x] 検索画面の実装

# ✅ Test

- [x] AndroidエミュレータとiOSシミュレーターで画面遷移することを確認

# 🔧 補足、備考

- 検索ボタンのみモーダルのため、ボトムナビゲーションの遷移処理を配列データとして定義するように変更しました。
  この配列データ内で、モーダルか否かや遷移画面、遷移先を定義するようにしています。

## 画面
**ボトムナビゲーション**
<image src="https://user-images.githubusercontent.com/56541594/215103515-e12ff47a-f8b7-4fb7-9eb0-8d6e12ab3760.png" width=50%/>

**画面遷移**
<image src="https://user-images.githubusercontent.com/56541594/215104276-94d8a5de-37a1-4a4d-b767-93bdd6cb8326.gif" height=500px/>


# 🔀 マージ条件

- [ ] レビューを通過する
- [ ] セルフマージする