### PR TITLE
✨検索フィルター画面への遷移処理作成

### DIFF
--- a/lib/app/components/pages/search/views/search_view.dart
+++ b/lib/app/components/pages/search/views/search_view.dart
@@ -2,16 +2,41 @@ import 'package:flutter/material.dart';
 
 import 'package:get/get.dart';
 
-import '../controllers/search_controller.dart';
+import 'package:favoritism_communication/app/styles/styles.dart';
+import 'package:favoritism_communication/app/components/organisms/nav_bar.dart';
+import 'package:favoritism_communication/app/components/pages/search/controllers/search_controller.dart';
+import 'package:favoritism_communication/app/routes/app_pages.dart';
 
 class SearchView extends GetView<SearchController> {
   const SearchView({Key? key}) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('SearchView'),
-        centerTitle: true,
+      backgroundColor: colorSearchBg,
+      appBar: NavBar(
+        backgroundColor: colorSearchAppBarBg,
+        toolbarHeight: 60,
+        trailing: <Widget>[
+          IconButton(
+            icon: const Icon(
+              Icons.tune,
+              size: 36,
+            ),
+            color: colorSearchAppBarIconFilter,
+            onPressed: () {
+              Get.toNamed(
+                Routes.searchFilter,
+              );
+            },
+          ),
+        ],
+        child: const Text("さがす",
+          style: TextStyle(
+            color: colorSearchAppBarTitle,
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+          )
+        ),
       ),
       body: const Center(
         child: Text(

--- a/lib/app/components/pages/search_filter/bindings/search_filter_binding.dart
+++ b/lib/app/components/pages/search_filter/bindings/search_filter_binding.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+
+import '../controllers/search_filter_controller.dart';
+
+class SearchFilterBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut<SearchFilterController>(
+      () => SearchFilterController(),
+    );
+  }
+}

--- a/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
+++ b/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
@@ -1,0 +1,4 @@
+import 'package:get/get.dart';
+
+class SearchFilterController extends GetxController {
+}

--- a/lib/app/components/pages/search_filter/views/search_filter_view.dart
+++ b/lib/app/components/pages/search_filter/views/search_filter_view.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import 'package:get/get.dart';
+
+import '../controllers/search_filter_controller.dart';
+
+class SearchFilterView extends GetView<SearchFilterController> {
+  const SearchFilterView({Key? key}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('SearchFilterView'),
+        centerTitle: true,
+      ),
+      body: const Center(
+        child: Text(
+          'SearchFilterView is working',
+          style: TextStyle(fontSize: 20),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -14,6 +14,8 @@ import '../components/pages/profile/bindings/profile_binding.dart';
 import '../components/pages/profile/views/profile_view.dart';
 import '../components/pages/search/bindings/search_binding.dart';
 import '../components/pages/search/views/search_view.dart';
+import '../components/pages/search_filter/bindings/search_filter_binding.dart';
+import '../components/pages/search_filter/views/search_filter_view.dart';
 import '../components/pages/talk_room/bindings/talk_room_binding.dart';
 import '../components/pages/talk_room/views/talk_room_view.dart';
 
@@ -66,6 +68,11 @@ class AppPages {
       name: _Paths.search,
       page: () => const SearchView(),
       binding: SearchBinding(),
+    ),
+    GetPage(
+      name: _Paths.searchFilter,
+      page: () => const SearchFilterView(),
+      binding: SearchFilterBinding(),
     ),
   ];
 }

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -73,6 +73,7 @@ class AppPages {
       name: _Paths.searchFilter,
       page: () => const SearchFilterView(),
       binding: SearchFilterBinding(),
+      fullscreenDialog: true,
     ),
   ];
 }

--- a/lib/app/routes/app_routes.dart
+++ b/lib/app/routes/app_routes.dart
@@ -11,6 +11,7 @@ abstract class Routes {
   static const profile = _Paths.profile;
   static const talkRoom = _Paths.talkRoom;
   static const search = _Paths.search;
+  static const searchFilter = _Paths.searchFilter;
 }
 
 abstract class _Paths {
@@ -23,4 +24,5 @@ abstract class _Paths {
   static const profile = '/profile';
   static const talkRoom = '/talk-room';
   static const search = '/search';
+  static const searchFilter = '$search/filter';
 }

--- a/lib/app/styles/app_theme_color.dart
+++ b/lib/app/styles/app_theme_color.dart
@@ -58,3 +58,8 @@ const colorMypageAppBarBg = Colors.pinkAccent;
 const colorTalkRoomAppBarBg = Colors.pink;
 const colorMatchingDialogButtonTextFg = Colors.white;
 const colorMatchingDialogButtonTextBg = Color(0xff0091ea);
+// "さがす"画面
+const colorSearchBg = Colors.white;                 // 背景色
+const colorSearchAppBarBg = Colors.white;           // Appbar背景色
+const colorSearchAppBarTitle = Colors.grey;         // タイトル文字色
+const colorSearchAppBarIconFilter = Colors.grey;    // フィルターアイコン色


### PR DESCRIPTION
# ✨ What's done

- [x] 検索画面のAppBarを実装
- [x] フィルターボタン押下時に画面をモーダルで表示

# 🚩 What's not done

- [ ] フィルター画面の実装

# ✅ Test

- [x] AndroidエミュレータとiOSシミュレータで画面表示確認
- [x] フィルターボタン押下時に画面遷移することを確認
- [x] フィルター画面で×ボタン押下時に画面が閉じることを確認

# 🔧 補足、備考

## 目的
- 検索処理実装のため

## 画面
<image src="https://user-images.githubusercontent.com/56541594/216743966-0e6d4ab5-d0d9-4d61-9a4b-44c6b33209f7.gif" height=500px/>


# 🔀 マージ条件

- [ ] レビューを通過する
- [ ] セルフマージする