### PR TITLE
FC-210 検索フィルターのジャンル選択画面の作成

### DIFF
--- a/lib/app/components/pages/search_select_genre/bindings/search_select_genre_binding.dart
+++ b/lib/app/components/pages/search_select_genre/bindings/search_select_genre_binding.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 
+import 'package:favoritism_communication/app/repository/genre_repository.dart';
 import '../controllers/search_select_genre_controller.dart';
 
 class SearchSelectGenreBinding extends Bindings {
@@ -7,6 +8,10 @@ class SearchSelectGenreBinding extends Bindings {
   void dependencies() {
     Get.lazyPut<SearchSelectGenreController>(
       () => SearchSelectGenreController(),
+    );
+
+    Get.lazyPut<IGenreRepository>(
+      () => GenreRepositoryStub(),  // ダミーデータのセット
     );
   }
 }

--- a/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
+++ b/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
@@ -1,3 +1,17 @@
+import 'package:favoritism_communication/app/repository/genre_repository.dart';
 import 'package:get/get.dart';
 
-class SearchSelectGenreController extends GetxController {}
+class SearchSelectGenreController extends GetxController {
+
+  Future<List<String>> get genreForSelect async {
+    IGenreRepository genreRepository = Get.find();
+    List<Map<String, dynamic>> genreMapList = await genreRepository.fetchUserGenre("0");
+    return genreMapList.map<String>(
+      (Map<String, dynamic> genreMap) {
+        return genreMap["title"];
+      }
+    ).toList();
+  }
+
+
+}

--- a/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
+++ b/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
@@ -1,17 +1,36 @@
 import 'package:favoritism_communication/app/repository/genre_repository.dart';
 import 'package:get/get.dart';
 
-class SearchSelectGenreController extends GetxController {
+class SearchGenreInfo {
+  SearchGenreInfo({
+    required this.id,
+    required this.title,
+    required this.isSelect,
+  });
 
-  Future<List<String>> get genreForSelect async {
-    IGenreRepository genreRepository = Get.find();
-    List<Map<String, dynamic>> genreMapList = await genreRepository.fetchUserGenre("0");
-    return genreMapList.map<String>(
-      (Map<String, dynamic> genreMap) {
-        return genreMap["title"];
-      }
-    ).toList();
+  final String id;
+  final String title;
+  final bool isSelect;
+}
+
+class SearchSelectGenreController extends GetxController {
+  //TODO: 最初の読み込み時に非同期でデータを取得する処理
+  //TODO: ジャンルが選択されたときにボタンをアクティブにする処理
+
+  void selectGenre(String id){
+
   }
 
+  Future<List<SearchGenreInfo>> get genreForSelect async {
+    final List<SearchGenreInfo> genreInfo = [];   // genreInfoのリスト
+    final IGenreRepository genreRepository = Get.find();
+    final List<Map<String, dynamic>> genreMapList = await genreRepository.fetchUserGenre("0");
 
+    for(Map<String, dynamic> genreMap in genreMapList){
+      genreInfo.add(
+        SearchGenreInfo(id: genreMap["genreId"], title: genreMap["title"], isSelect: false)
+      );
+    }
+    return genreInfo;
+  }
 }

--- a/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
+++ b/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
@@ -14,23 +14,37 @@ class SearchGenreInfo {
 }
 
 class SearchSelectGenreController extends GetxController {
-  //TODO: 最初の読み込み時に非同期でデータを取得する処理
-  //TODO: ジャンルが選択されたときにボタンをアクティブにする処理
+  late final List<Map<String, dynamic>> _genreMapList;
+  final RxList<SearchGenreInfo> genreForSelect = <SearchGenreInfo>[].obs;
+  String _selectGenreId = "";
 
-  void selectGenre(String id){
+  @override
+  void onInit() async{
+    final IGenreRepository genreRepository = Get.find();
+    _genreMapList = await genreRepository.fetchUserGenre("0");  //TODO: ユーザIDを渡す
+    _constructGenreInfoList(_genreMapList);
 
+    super.onInit();
   }
 
-  Future<List<SearchGenreInfo>> get genreForSelect async {
-    final List<SearchGenreInfo> genreInfo = [];   // genreInfoのリスト
-    final IGenreRepository genreRepository = Get.find();
-    final List<Map<String, dynamic>> genreMapList = await genreRepository.fetchUserGenre("0");
-
+  void _constructGenreInfoList(List<Map<String, dynamic>> genreMapList){
+    genreForSelect.clear();
     for(Map<String, dynamic> genreMap in genreMapList){
-      genreInfo.add(
-        SearchGenreInfo(id: genreMap["genreId"], title: genreMap["title"], isSelect: false)
+      final isSelect = genreMap["genreId"] == _selectGenreId;
+      genreForSelect.add(
+          SearchGenreInfo(id: genreMap["genreId"], title: genreMap["title"], isSelect: isSelect)
       );
     }
-    return genreInfo;
+    genreForSelect.refresh();
+  }
+
+  void selectGenre(String id){
+    if(_selectGenreId == id){
+      _selectGenreId = "";
+    }
+    else{
+      _selectGenreId = id;
+    }
+    _constructGenreInfoList(_genreMapList);
   }
 }

--- a/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
+++ b/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
-
 import 'package:get/get.dart';
+
+import 'package:favoritism_communication/app/styles/styles.dart';
+import 'package:favoritism_communication/app/components/organisms/nav_bar.dart';
+import 'package:favoritism_communication/app/components/atoms/alternate_circle_chip.dart';
 
 import '../controllers/search_select_genre_controller.dart';
 
@@ -9,16 +12,63 @@ class SearchSelectGenreView extends GetView<SearchSelectGenreController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('SearchSelectGenreView'),
-        centerTitle: true,
-      ),
-      body: const Center(
-        child: Text(
-          'SearchSelectGenreView is working',
-          style: TextStyle(fontSize: 20),
+      // backgroundColor: colorSearchFilterBg,
+      appBar: NavBar(
+        backgroundColor: Colors.white,
+        toolbarHeight: 60,
+        leading: IconButton(
+          icon: const Icon(
+            Icons.arrow_back_ios,
+            size: 36,
+          ),
+          color: Colors.grey,
+          onPressed: () {
+            Get.back();
+          },
+        ),
+        child: const Text("ジャンル",
+          style: TextStyle(
+            color: Colors.grey,
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+          )
         ),
       ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.only(bottom: 16.0),
+              child: Text("ジャンルを1個選択してください",
+                style: TextStyle(
+                  color: Colors.grey,
+                  fontWeight: FontWeight.bold,
+                )
+              ),
+            ),
+
+            FutureBuilder<List<String>>(
+              future: controller.genreForSelect,
+              builder: (BuildContext context, AsyncSnapshot<List<String>> snapshot){
+                List<String> genreTitles = snapshot.data ?? [];
+                return Wrap(
+                  runSpacing: 4.0,
+                  spacing: 4.0,
+                  children: genreTitles.map<Widget>((title) {
+                    return AlternateCircleChip(
+                      isPushed: false,
+                      onPressed: null,
+                      child: Text(title),
+                    );
+                  }).toList(),
+                );
+              },
+            ),
+          ],
+        ),
+      )
     );
   }
 }

--- a/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
+++ b/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
@@ -48,32 +48,32 @@ class SearchSelectGenreView extends GetView<SearchSelectGenreController> {
                 )
               ),
             ),
-
-            FutureBuilder<List<SearchGenreInfo>>(
-              future: controller.genreForSelect,
-              builder: (BuildContext context, AsyncSnapshot<List<SearchGenreInfo>> snapshot){
-                List<SearchGenreInfo> genreInfo = snapshot.data ?? [];
-                List<Widget> genreChips = [];
-                for(SearchGenreInfo info in genreInfo){
-                  genreChips.add(
-                    AlternateCircleChip(
-                      isPushed: info.isSelect,
-                      onPressed: () => controller.selectGenre(info.id),
-                      child: Text(info.title),
-                    )
-                  );
-                }
-
-                return Wrap(
-                  runSpacing: 4.0,
-                  spacing: 4.0,
-                  children: genreChips,
-                );
-              },
-            ),
+            Obx(() => _buildGenreButton(
+                controller.genreForSelect,
+              ),
+            )
           ],
         ),
       )
+    );
+  }
+
+  Widget _buildGenreButton(List<SearchGenreInfo> genreInfo){
+    List<Widget> genreChips = [];
+    for(SearchGenreInfo info in genreInfo){
+      genreChips.add(
+        AlternateCircleChip(
+          isPushed: info.isSelect,
+          onPressed: () => controller.selectGenre(info.id),
+          child: Text(info.title),
+        ),
+      );
+    }
+
+    return Wrap(
+      runSpacing: 4.0,
+      spacing: 4.0,
+      children: genreChips,
     );
   }
 }

--- a/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
+++ b/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
@@ -49,20 +49,25 @@ class SearchSelectGenreView extends GetView<SearchSelectGenreController> {
               ),
             ),
 
-            FutureBuilder<List<String>>(
+            FutureBuilder<List<SearchGenreInfo>>(
               future: controller.genreForSelect,
-              builder: (BuildContext context, AsyncSnapshot<List<String>> snapshot){
-                List<String> genreTitles = snapshot.data ?? [];
+              builder: (BuildContext context, AsyncSnapshot<List<SearchGenreInfo>> snapshot){
+                List<SearchGenreInfo> genreInfo = snapshot.data ?? [];
+                List<Widget> genreChips = [];
+                for(SearchGenreInfo info in genreInfo){
+                  genreChips.add(
+                    AlternateCircleChip(
+                      isPushed: info.isSelect,
+                      onPressed: () => controller.selectGenre(info.id),
+                      child: Text(info.title),
+                    )
+                  );
+                }
+
                 return Wrap(
                   runSpacing: 4.0,
                   spacing: 4.0,
-                  children: genreTitles.map<Widget>((title) {
-                    return AlternateCircleChip(
-                      isPushed: false,
-                      onPressed: null,
-                      child: Text(title),
-                    );
-                  }).toList(),
+                  children: genreChips,
                 );
               },
             ),

--- a/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
+++ b/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
@@ -12,23 +12,23 @@ class SearchSelectGenreView extends GetView<SearchSelectGenreController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      // backgroundColor: colorSearchFilterBg,
+      backgroundColor: colorSearchGenreFilterBg,
       appBar: NavBar(
-        backgroundColor: Colors.white,
+        backgroundColor: colorSearchGenreAppBarBg,
         toolbarHeight: 60,
         leading: IconButton(
           icon: const Icon(
             Icons.arrow_back_ios,
             size: 36,
           ),
-          color: Colors.grey,
+          color: colorSearchGenreAppBarTitle,
           onPressed: () {
             Get.back();
           },
         ),
         child: const Text("ジャンル",
           style: TextStyle(
-            color: Colors.grey,
+            color: colorSearchGenreAppBarTitle,
             fontSize: 18,
             fontWeight: FontWeight.bold,
           )
@@ -43,7 +43,7 @@ class SearchSelectGenreView extends GetView<SearchSelectGenreController> {
               padding: EdgeInsets.only(bottom: 16.0),
               child: Text("ジャンルを1個選択してください",
                 style: TextStyle(
-                  color: Colors.grey,
+                  color: colorSearchGenreText,
                   fontWeight: FontWeight.bold,
                 )
               ),

--- a/lib/app/repository/genre_repository.dart
+++ b/lib/app/repository/genre_repository.dart
@@ -1,12 +1,12 @@
 // ジャンルリポジトリクラスインターフェース
 abstract class IGenreRepository{
-  List<Map<String, dynamic>> fetchUserGenre(String userId);
+  Future<List<Map<String, dynamic>>> fetchUserGenre(String userId);
 }
 
 // テスト用ダミーデータリポジトリクラス
 class GenreRepositoryStub extends IGenreRepository{
   @override
-  List<Map<String, dynamic>> fetchUserGenre(String userId){
+  Future<List<Map<String, dynamic>>> fetchUserGenre(String userId) async{
     return [
       {
         'userId': '001',

--- a/lib/app/styles/app_theme_color.dart
+++ b/lib/app/styles/app_theme_color.dart
@@ -74,3 +74,9 @@ const colorSearchButtonFg = Colors.white;
 const colorSearchButtonBg = Color.fromRGBO(236, 188, 179, 1);
 const colorClearSearchFilterButtonFg = Colors.grey;
 const colorClearSearchFilterButtonBg = Colors.white;
+// ジャンル画面
+const colorSearchGenreFilterBg = Colors.white; // 背景色
+const colorSearchGenreAppBarBg = Colors.white; // Appbar背景色
+const colorSearchGenreAppBarTitle = Colors.grey; // タイトル文字色
+const colorSearchGenreText = Colors.grey;      // 文字色
+


### PR DESCRIPTION
# ✨ What's done

- [x] ジャンル選択画面の作成
- [x] ダミーデータからジャンルを表示
- [x] ジャンルボタン押下で選択できる処理作成

# ✅ Test
- [x] Androidエミュレータで動作確認
- [x] 各ボタンを押下して、ボタンの表示が変わることを確認
- [x] 選択が1つしかされないことを確認
- [x] 選択されているボタンを再度押下すると、非選択状態になることを確認

# 🔧 補足、備考

- 目的：ジャンル選択画面実装のため
- ジャンル非選択状態
  <image src="https://github.com/Team-Ganju/favoritism_communication/assets/56541594/d2d3b45b-353e-402e-9b4f-0eae11a44f06" width=200px/> 

- ジャンル選択状態
  <image src="https://github.com/Team-Ganju/favoritism_communication/assets/56541594/b8529d15-ff92-4ec0-8255-5372cd38dc28" width=200px/> 

# 🔀 マージ条件

- [ ] レビューを通過する
- [ ] セルフマージする