### PR TITLE
✨FC-211 検索フィルター画面とジャンル選択画面間で値を引き継ぐ処理の作成

### DIFF
--- a/lib/app/components/pages/search_filter/bindings/search_filter_binding.dart
+++ b/lib/app/components/pages/search_filter/bindings/search_filter_binding.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:favoritism_communication/app/repository/genre_repository.dart';
 
 import '../controllers/search_filter_controller.dart';
 
@@ -8,5 +9,8 @@ class SearchFilterBinding extends Bindings {
     Get.lazyPut<SearchFilterController>(
       () => SearchFilterController(),
     );
+    Get.lazyPut<IGenreRepository>(
+      () => GenreRepositoryStub(),
+   );
   }
 }

--- a/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
+++ b/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
@@ -8,8 +8,8 @@ class SearchFilterController extends GetxController {
   final Rx<Map<String, Map<String, dynamic>>> _genreMap = Rx<Map<String, Map<String, dynamic>>>({}); // idとjsonデータのマップ
 
   @override
-  void onInit() async{
-    updateGenreMap();
+  Future<void> onInit() async{
+    await updateGenreMap();
     // 初期値で性別は全てTrueにする
     for (Gender gender in Gender.values) {
       changeGender(gender, true);
@@ -17,7 +17,7 @@ class SearchFilterController extends GetxController {
     super.onInit();
   }
 
-  Future updateGenreMap() async {
+  Future<void> updateGenreMap() async {
     final IGenreRepository genreRepository = Get.find();
     _genreMap.value = _createGenreMap(await genreRepository.fetchUserGenre("0"));  //TODO: ユーザIDを渡す
   }

--- a/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
+++ b/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
@@ -30,7 +30,12 @@ class SearchFilterController extends GetxController {
     return map;
   }
 
-  set genre(String v){
+  String get genreId {
+    if(_genreIds.value.isEmpty) return "";
+    return _genreIds.value.first;
+  }
+
+  set genreId(String v){
     updateGenreMap();
     _genreIds.value = [v];
   }

--- a/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
+++ b/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
@@ -37,7 +37,12 @@ class SearchFilterController extends GetxController {
 
   set genreId(String v){
     updateGenreMap();
-    _genreIds.value = [v];
+    if(v != ""){
+      _genreIds.value = [v];
+    }
+    else{
+      _genreIds.value = [];
+    }
   }
 
   List<String> get selectedCategoryNames {

--- a/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
+++ b/lib/app/components/pages/search_filter/controllers/search_filter_controller.dart
@@ -1,16 +1,38 @@
 import 'package:get/get.dart';
 import 'package:favoritism_communication/app/data/gender/gender.dart';
+import 'package:favoritism_communication/app/repository/genre_repository.dart';
 
 class SearchFilterController extends GetxController {
   final Rx<Map<Gender, bool>> _gender = Rx<Map<Gender, bool>>({});
+  final Rx<List<String>> _genreIds = Rx<List<String>>([]);
+  final Rx<Map<String, Map<String, dynamic>>> _genreMap = Rx<Map<String, Map<String, dynamic>>>({}); // idとjsonデータのマップ
 
   @override
-  void onInit() {
-    super.onInit();
+  void onInit() async{
+    updateGenreMap();
     // 初期値で性別は全てTrueにする
     for (Gender gender in Gender.values) {
       changeGender(gender, true);
     }
+    super.onInit();
+  }
+
+  Future updateGenreMap() async {
+    final IGenreRepository genreRepository = Get.find();
+    _genreMap.value = _createGenreMap(await genreRepository.fetchUserGenre("0"));  //TODO: ユーザIDを渡す
+  }
+
+  Map<String, Map<String, dynamic>> _createGenreMap(List<Map<String, dynamic>> mapList){
+    final Map<String, Map<String, dynamic>> map = {};
+    for(Map<String, dynamic> genre in mapList){
+      map[genre["genreId"]] = genre;
+    }
+    return map;
+  }
+
+  set genre(String v){
+    updateGenreMap();
+    _genreIds.value = [v];
   }
 
   List<String> get selectedCategoryNames {
@@ -30,19 +52,16 @@ class SearchFilterController extends GetxController {
   }
 
   List<String> get selectedGenreNames {
-    //TODO: 選択されたジャンルを返す処理
-    return [
-      // "ジャンル1",
-      // "ジャンル2",
-      // "ジャンル3",
-      // "ジャンル4",
-      // "ジャンル5",
-      // "ジャンル6",
-      // "ジャンル7",
-      // "ジャンル8",
-      // "ジャンル9",
-      // "ジャンル10",
-    ];
+    return _genreIds.value.map((e){
+        var title = _genreMap.value[e]?["title"];
+        if(title is String){
+          return title;
+        }
+        else{
+          return "";
+        }
+      }
+    ).toList();
   }
 
   List<String> get belongCommunities {
@@ -61,4 +80,5 @@ class SearchFilterController extends GetxController {
     clone[gender] = value ?? false;
     _gender.value = clone;
   }
+
 }

--- a/lib/app/components/pages/search_filter/views/search_filter_view.dart
+++ b/lib/app/components/pages/search_filter/views/search_filter_view.dart
@@ -45,14 +45,14 @@ class SearchFilterView extends GetView<SearchFilterController> {
             padding: const EdgeInsets.all(8.0),
             physics: const NeverScrollableScrollPhysics(),
             children: <Widget>[
-              MultiOptionSelectButton(
+              Obx(() =>MultiOptionSelectButton(
                 selectedItems: controller.selectedGenreNames
-                    .map((name) => AlternateCircleChip(
-                          isPushed: false,
-                          onPressed: null,
-                          child: Text(name),
-                        ))
-                    .toList(),
+                    .map((name) =>AlternateCircleChip(
+                  isPushed: true,
+                  onPressed: null,
+                  child: Text(name),
+                )
+                ).toList(),
                 label: 'ジャンル',
                 emptyChild: const Text(
                   'こだわらない',
@@ -62,10 +62,12 @@ class SearchFilterView extends GetView<SearchFilterController> {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                onTap: () => Get.toNamed(
-                  Routes.searchSelectGenre,
-                ),
-              ),
+                onTap: () async {
+                  controller.genre = await Get.toNamed(
+                    Routes.searchSelectGenre,
+                  );
+                },
+              )),
               MultiOptionSelectButton(
                 selectedItems: controller.selectedCategoryNames
                     .map((name) => CustomChip(

--- a/lib/app/components/pages/search_filter/views/search_filter_view.dart
+++ b/lib/app/components/pages/search_filter/views/search_filter_view.dart
@@ -63,8 +63,11 @@ class SearchFilterView extends GetView<SearchFilterController> {
                   ),
                 ),
                 onTap: () async {
-                  controller.genre = await Get.toNamed(
+                  controller.genreId = await Get.toNamed(
                     Routes.searchSelectGenre,
+                    parameters: {
+                      "selected": controller.genreId,
+                    }
                   );
                 },
               )),

--- a/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
+++ b/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
@@ -17,6 +17,7 @@ class SearchSelectGenreController extends GetxController {
   late final List<Map<String, dynamic>> _genreMapList;
   final RxList<SearchGenreInfo> genreForSelect = <SearchGenreInfo>[].obs;
   String _selectGenreId = "";
+  String get genreId => _selectGenreId;
 
   @override
   void onInit() async{

--- a/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
+++ b/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
@@ -20,7 +20,7 @@ class SearchSelectGenreController extends GetxController {
   String get genreId => _selectGenreId;
 
   @override
-  void onInit() async{
+  Future<void> onInit() async{
     final IGenreRepository genreRepository = Get.find();
     _genreMapList = await genreRepository.fetchUserGenre("0");  //TODO: ユーザIDを渡す
     _selectGenreId = Get.parameters["selected"] ?? "";

--- a/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
+++ b/lib/app/components/pages/search_select_genre/controllers/search_select_genre_controller.dart
@@ -23,8 +23,8 @@ class SearchSelectGenreController extends GetxController {
   void onInit() async{
     final IGenreRepository genreRepository = Get.find();
     _genreMapList = await genreRepository.fetchUserGenre("0");  //TODO: ユーザIDを渡す
+    _selectGenreId = Get.parameters["selected"] ?? "";
     _constructGenreInfoList(_genreMapList);
-
     super.onInit();
   }
 

--- a/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
+++ b/lib/app/components/pages/search_select_genre/views/search_select_genre_view.dart
@@ -23,7 +23,7 @@ class SearchSelectGenreView extends GetView<SearchSelectGenreController> {
           ),
           color: colorSearchGenreAppBarTitle,
           onPressed: () {
-            Get.back();
+            Get.back(result: controller.genreId);
           },
         ),
         child: const Text("ジャンル",


### PR DESCRIPTION
# ✨ What's done
- [x] 検索フィルター画面からジャンル選択画面へ遷移時に値を引き継ぐ処理の作成
- [x] ジャンル選択画面から検索フィルター画面へ遷移時に値を引き継ぐ処理の作成

# ✅ Test
- [x] Androidエミュレータで確認
  - [x] ジャンル選択画面で指定した値が検索フィルター画面で表示されていること
  - [x] 検索フィルター画面で表示されていた値がジャンル選択画面で押下状態になっていること

# 🔧 補足、備考
![favoritism_comm_FC-211](https://github.com/Team-Ganju/favoritism_communication/assets/56541594/7bd7a017-9dc8-428b-8c5e-c3479371f760)


# 🔀 マージ条件
- [ ] レビューを通過する
- [ ] セルフマージする